### PR TITLE
Tighten path matching, return errors, simplify API (v3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A skipper utility for the [Echo](https://echo.labstack.com/) web framework in Go
     - [echo-sentry-middleware](https://github.com/adlandh/echo-sentry-middleware)
 - Supports both exact endpoint matching and regular expression pattern matching
 - Separate skip lists for request and response bodies
-- Safe behavior when config is empty or regex patterns are invalid
+- Safe behavior when config is empty; invalid regex patterns are reported as errors at construction time
 
 ## Installation
 
@@ -24,16 +24,19 @@ go get github.com/adlandh/echo-dump-body-skipper/v2
 e := echo.New()
 
 // Example: Use skipper to skip body dump for health check endpoint
-skipper := echodumpbodyskipper.NewEchoDumpBodySkipper(
+skipper, err := echodumpbodyskipper.New(
 	echodumpbodyskipper.SkipperConf{
         DumpNoResponseBodyForPaths: []string{"/health"},
 })
+if err != nil {
+    log.Fatal(err)
+}
 
-app.Use(echootelmiddleware.MiddlewareWithConfig(echootelmiddleware.OtelConfig{
+e.Use(echootelmiddleware.MiddlewareWithConfig(echootelmiddleware.OtelConfig{
     AreHeadersDump: true, // dump request && response headers
     IsBodyDump:     true, // dump request && response body
     // No dump for health check endpoint
-    BodySkipper: skipper.Skip,
+    BodySkipper: skipper,
 }))
 ```
 
@@ -51,18 +54,18 @@ Each list can include:
 
 Matching rules:
 
-- Exact route checks compare against `echo.Context.Path()`
-- For regex patterns, prefer anchoring with `^...$` for clarity and to avoid unintended matches
-- Regex checks compare against `echo.Context.Request().URL.Path`
-- Query strings are ignored for regex matching since only the path is checked
-- Invalid regex patterns are silently ignored
+- Entries containing `/:` or `/*` (or ending in `*`) are treated as Echo route templates and matched against `echo.Context.Path()`
+- All other entries are treated as regular expressions and matched against `echo.Context.Request().URL.Path`
+- Regex entries are auto-anchored with `^...$` if not already anchored, so a literal like `/users` matches `/users` exactly and not `/users/123`
+- Query strings are ignored since only the path is checked
+- Invalid regex patterns cause `New` to return an error
 
 ### Examples
 
 Skip request body for any `/users/:id` route while skipping response body for a specific path:
 
 ```go
-skipper := echodumpbodyskipper.NewEchoDumpBodySkipper(
+skipper, err := echodumpbodyskipper.New(
 	echodumpbodyskipper.SkipperConf{
 		DumpNoRequestBodyForPaths: []string{
 			"/users/:id",
@@ -79,7 +82,7 @@ skipper := echodumpbodyskipper.NewEchoDumpBodySkipper(
 #### echo-otel-middleware
 
 ```go
-skipper := echodumpbodyskipper.NewEchoDumpBodySkipper(
+skipper, err := echodumpbodyskipper.New(
 	echodumpbodyskipper.SkipperConf{
 		DumpNoResponseBodyForPaths: []string{
 			"/health",
@@ -90,14 +93,14 @@ skipper := echodumpbodyskipper.NewEchoDumpBodySkipper(
 e.Use(echootelmiddleware.MiddlewareWithConfig(echootelmiddleware.OtelConfig{
 	AreHeadersDump: true,
 	IsBodyDump:     true,
-	BodySkipper:    skipper.Skip,
+	BodySkipper:    skipper,
 }))
 ```
 
 #### echo-sentry-middleware
 
 ```go
-skipper := echodumpbodyskipper.NewEchoDumpBodySkipper(
+skipper, err := echodumpbodyskipper.New(
 	echodumpbodyskipper.SkipperConf{
 		DumpNoRequestBodyForPaths: []string{
 			"/auth/:provider/callback",
@@ -106,7 +109,7 @@ skipper := echodumpbodyskipper.NewEchoDumpBodySkipper(
 )
 
 e.Use(echosentry.MiddlewareWithConfig(echosentry.Config{
-	BodySkipper: skipper.Skip,
+	BodySkipper: skipper,
 }))
 ```
 

--- a/skipper.go
+++ b/skipper.go
@@ -2,67 +2,74 @@
 package echodumpbodyskipper
 
 import (
+	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/labstack/echo/v5"
 )
 
-type BodySkipper struct {
-	Skip                   func(*echo.Context) (skipReqBody bool, skipRespBody bool)
-	exactExcludedPathsReq  map[string]struct{}
-	exactExcludedPathsResp map[string]struct{}
-	regexExcludedPathsReq  []*regexp.Regexp
-	regexExcludedPathsResp []*regexp.Regexp
-}
+// Skipper reports, for the current request, whether the request body and/or
+// response body should be skipped from dumping. It is suitable for use as a
+// BodySkipper in middlewares such as echo-otel-middleware and
+// echo-sentry-middleware.
+type Skipper func(c *echo.Context) (skipReqBody bool, skipRespBody bool)
 
+// SkipperConf configures which paths should have their request and/or response
+// bodies excluded from dumping.
 type SkipperConf struct {
-	// paths (regular expressions) or endpoints (ex: `/ping/:id`) to exclude from dumping response bodies
+	// DumpNoResponseBodyForPaths lists patterns whose responses should not be
+	// dumped. Entries containing `/:` or `/*` (or ending in `*`) are treated as
+	// Echo route templates and matched against c.Path(). All other entries are
+	// treated as regular expressions matched against the request URL path; they
+	// are auto-anchored with ^...$ so a literal like "/users" matches "/users"
+	// exactly and not "/users/123".
 	DumpNoResponseBodyForPaths []string
 
-	// paths (regular expressions) or endpoints (ex: `/ping/:id`) to exclude from dumping request bodies
+	// DumpNoRequestBodyForPaths lists patterns whose requests should not be
+	// dumped. See DumpNoResponseBodyForPaths for matching rules.
 	DumpNoRequestBodyForPaths []string
 }
 
-func (b *BodySkipper) prepareRegexps(config SkipperConf) {
-	b.regexExcludedPathsResp = make([]*regexp.Regexp, 0, len(config.DumpNoResponseBodyForPaths))
-	b.regexExcludedPathsReq = make([]*regexp.Regexp, 0, len(config.DumpNoRequestBodyForPaths))
-	b.exactExcludedPathsResp = make(map[string]struct{}, len(config.DumpNoResponseBodyForPaths))
-	b.exactExcludedPathsReq = make(map[string]struct{}, len(config.DumpNoRequestBodyForPaths))
+// isRouteTemplate reports whether p looks like an Echo route template
+// (containing a `:param` or `*` segment) rather than a regular expression.
+func isRouteTemplate(p string) bool {
+	return strings.Contains(p, "/:") || strings.Contains(p, "/*") || strings.HasSuffix(p, "*")
+}
 
-	if len(config.DumpNoResponseBodyForPaths) > 0 {
-		for _, path := range config.DumpNoResponseBodyForPaths {
-			b.exactExcludedPathsResp[path] = struct{}{}
+func classifyPaths(field string, paths []string) (map[string]struct{}, []*regexp.Regexp, error) {
+	exact := make(map[string]struct{}, len(paths))
+	regexes := make([]*regexp.Regexp, 0, len(paths))
 
-			regexExcludedPath, err := regexp.Compile(path)
-			if err != nil {
-				// if the pattern is invalid / not regular expression - just ignore it
-				continue
-			}
-
-			b.regexExcludedPathsResp = append(b.regexExcludedPathsResp, regexExcludedPath)
+	for _, path := range paths {
+		if isRouteTemplate(path) {
+			exact[path] = struct{}{}
+			continue
 		}
+
+		pattern := path
+		if !strings.HasPrefix(pattern, "^") {
+			pattern = "^" + pattern
+		}
+
+		if !strings.HasSuffix(pattern, "$") {
+			pattern += "$"
+		}
+
+		re, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%s: invalid regex %q: %w", field, path, err)
+		}
+
+		regexes = append(regexes, re)
 	}
 
-	if len(config.DumpNoRequestBodyForPaths) > 0 {
-		for _, path := range config.DumpNoRequestBodyForPaths {
-			b.exactExcludedPathsReq[path] = struct{}{}
-
-			regexExcludedPath, err := regexp.Compile(path)
-			if err != nil {
-				// if the pattern is invalid / not regular expression - just ignore it
-				continue
-			}
-
-			b.regexExcludedPathsReq = append(b.regexExcludedPathsReq, regexExcludedPath)
-		}
-	}
+	return exact, regexes, nil
 }
 
 func isExcluded(path string, endpoint string, regexps []*regexp.Regexp, endpoints map[string]struct{}) bool {
-	if len(endpoints) > 0 {
-		if _, ok := endpoints[endpoint]; ok {
-			return true
-		}
+	if _, ok := endpoints[endpoint]; ok {
+		return true
 	}
 
 	for _, regexExcludedPath := range regexps {
@@ -74,25 +81,33 @@ func isExcluded(path string, endpoint string, regexps []*regexp.Regexp, endpoint
 	return false
 }
 
-func NewEchoDumpBodySkipper(config SkipperConf) *BodySkipper {
-	b := &BodySkipper{}
-
+// New builds a Skipper from the given configuration. When the config is empty,
+// the returned Skipper is a no-op that always returns (false, false). An error
+// is returned if any non-template pattern in the configuration fails to
+// compile as a regular expression.
+func New(config SkipperConf) (Skipper, error) {
 	if len(config.DumpNoResponseBodyForPaths) == 0 && len(config.DumpNoRequestBodyForPaths) == 0 {
-		b.Skip = func(*echo.Context) (bool, bool) {
+		return func(*echo.Context) (bool, bool) {
 			return false, false
-		}
-
-		return b
+		}, nil
 	}
 
-	b.prepareRegexps(config)
+	exactResp, regexResp, err := classifyPaths("DumpNoResponseBodyForPaths", config.DumpNoResponseBodyForPaths)
+	if err != nil {
+		return nil, err
+	}
 
-	b.Skip = func(c *echo.Context) (bool, bool) {
-		skipReqBody := isExcluded(c.Request().URL.Path, c.Path(), b.regexExcludedPathsReq, b.exactExcludedPathsReq)
-		skipRespBody := isExcluded(c.Request().URL.Path, c.Path(), b.regexExcludedPathsResp, b.exactExcludedPathsResp)
+	exactReq, regexReq, err := classifyPaths("DumpNoRequestBodyForPaths", config.DumpNoRequestBodyForPaths)
+	if err != nil {
+		return nil, err
+	}
+
+	return func(c *echo.Context) (bool, bool) {
+		urlPath := c.Request().URL.Path
+		route := c.Path()
+		skipReqBody := isExcluded(urlPath, route, regexReq, exactReq)
+		skipRespBody := isExcluded(urlPath, route, regexResp, exactResp)
 
 		return skipReqBody, skipRespBody
-	}
-
-	return b
+	}, nil
 }

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -4,7 +4,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"strings"
 	"testing"
 
 	"github.com/labstack/echo/v5"
@@ -22,134 +21,27 @@ func newContext(method, path, route string, body io.Reader) *echo.Context {
 }
 
 func TestSkipper(t *testing.T) {
+	req := func(paths ...string) SkipperConf { return SkipperConf{DumpNoRequestBodyForPaths: paths} }
+	resp := func(paths ...string) SkipperConf { return SkipperConf{DumpNoResponseBodyForPaths: paths} }
+	both := func(reqs, resps []string) SkipperConf {
+		return SkipperConf{DumpNoRequestBodyForPaths: reqs, DumpNoResponseBodyForPaths: resps}
+	}
+
 	tests := []struct {
 		name                      string
 		conf                      SkipperConf
-		method                    string
-		path                      string
-		route                     string
-		body                      io.Reader
+		path, route               string
 		wantSkipReq, wantSkipResp bool
 	}{
-		{
-			name:         "no config returns false",
-			conf:         SkipperConf{},
-			method:       http.MethodGet,
-			path:         "/ping/121?qs=1",
-			route:        "/ping/:id",
-			wantSkipReq:  false,
-			wantSkipResp: false,
-		},
-		{
-			name: "exclude response body via regex",
-			conf: SkipperConf{
-				DumpNoResponseBodyForPaths: []string{
-					"^/ping/121$",
-				},
-			},
-			method:       http.MethodGet,
-			path:         "/ping/121?sdsdds=1212",
-			route:        "/ping/:id",
-			wantSkipReq:  false,
-			wantSkipResp: true,
-		},
-		{
-			name: "exclude request body via endpoint",
-			conf: SkipperConf{
-				DumpNoRequestBodyForPaths: []string{
-					"/ping/:id",
-				},
-			},
-			method:       http.MethodGet,
-			path:         "/ping/123",
-			route:        "/ping/:id",
-			body:         strings.NewReader("test"),
-			wantSkipReq:  true,
-			wantSkipResp: false,
-		},
-		{
-			name: "exclude both request and response bodies",
-			conf: SkipperConf{
-				DumpNoRequestBodyForPaths: []string{
-					"/ping/:id",
-				},
-				DumpNoResponseBodyForPaths: []string{
-					"^/ping/121$",
-				},
-			},
-			method:       http.MethodGet,
-			path:         "/ping/121",
-			route:        "/ping/:id",
-			body:         strings.NewReader("test"),
-			wantSkipReq:  true,
-			wantSkipResp: true,
-		},
-		{
-			name: "literal path is anchored - does not match longer URL",
-			conf: SkipperConf{
-				DumpNoResponseBodyForPaths: []string{
-					"/users",
-				},
-			},
-			method:       http.MethodGet,
-			path:         "/users/123",
-			route:        "/users/:id",
-			wantSkipReq:  false,
-			wantSkipResp: false,
-		},
-		{
-			name: "literal path matches exactly",
-			conf: SkipperConf{
-				DumpNoResponseBodyForPaths: []string{
-					"/users",
-				},
-			},
-			method:       http.MethodGet,
-			path:         "/users",
-			route:        "/users",
-			wantSkipReq:  false,
-			wantSkipResp: true,
-		},
-		{
-			name: "route template is not treated as regex against URL path",
-			conf: SkipperConf{
-				DumpNoRequestBodyForPaths: []string{
-					"/ping/:id",
-				},
-			},
-			method:       http.MethodGet,
-			path:         "/ping/:id-debug",
-			route:        "/other/:id",
-			wantSkipReq:  false,
-			wantSkipResp: false,
-		},
-		{
-			name: "wildcard route template matched via endpoint",
-			conf: SkipperConf{
-				DumpNoRequestBodyForPaths: []string{
-					"/files/*",
-				},
-			},
-			method:       http.MethodGet,
-			path:         "/files/a/b",
-			route:        "/files/*",
-			body:         strings.NewReader("test"),
-			wantSkipReq:  true,
-			wantSkipResp: false,
-		},
-		{
-			name: "regex non-match does not skip",
-			conf: SkipperConf{
-				DumpNoResponseBodyForPaths: []string{
-					"^/pong/123$",
-				},
-			},
-			method:       http.MethodGet,
-			path:         "/ping/121",
-			route:        "/ping/:id",
-			wantSkipReq:  false,
-			wantSkipResp: false,
-		},
+		{"no config returns false", SkipperConf{}, "/ping/121?qs=1", "/ping/:id", false, false},
+		{"exclude response body via regex", resp("^/ping/121$"), "/ping/121?sdsdds=1212", "/ping/:id", false, true},
+		{"exclude request body via endpoint", req("/ping/:id"), "/ping/123", "/ping/:id", true, false},
+		{"exclude both request and response bodies", both([]string{"/ping/:id"}, []string{"^/ping/121$"}), "/ping/121", "/ping/:id", true, true},
+		{"literal path is anchored - does not match longer URL", resp("/users"), "/users/123", "/users/:id", false, false},
+		{"literal path matches exactly", resp("/users"), "/users", "/users", false, true},
+		{"route template is not treated as regex against URL path", req("/ping/:id"), "/ping/:id-debug", "/other/:id", false, false},
+		{"wildcard route template matched via endpoint", req("/files/*"), "/files/a/b", "/files/*", true, false},
+		{"regex non-match does not skip", resp("^/pong/123$"), "/ping/121", "/ping/:id", false, false},
 	}
 
 	for _, tt := range tests {
@@ -157,7 +49,7 @@ func TestSkipper(t *testing.T) {
 			skipper, err := New(tt.conf)
 			require.NoError(t, err)
 
-			ctx := newContext(tt.method, tt.path, tt.route, tt.body)
+			ctx := newContext(http.MethodGet, tt.path, tt.route, nil)
 			skipReqBody, skipRespBody := skipper(ctx)
 			require.Equal(t, tt.wantSkipReq, skipReqBody)
 			require.Equal(t, tt.wantSkipResp, skipRespBody)

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -68,19 +68,6 @@ func TestSkipper(t *testing.T) {
 			wantSkipResp: false,
 		},
 		{
-			name: "invalid regex is ignored",
-			conf: SkipperConf{
-				DumpNoResponseBodyForPaths: []string{
-					"[",
-				},
-			},
-			method:       http.MethodGet,
-			path:         "/ping/121",
-			route:        "/ping/:id",
-			wantSkipReq:  false,
-			wantSkipResp: false,
-		},
-		{
 			name: "exclude both request and response bodies",
 			conf: SkipperConf{
 				DumpNoRequestBodyForPaths: []string{
@@ -96,6 +83,59 @@ func TestSkipper(t *testing.T) {
 			body:         strings.NewReader("test"),
 			wantSkipReq:  true,
 			wantSkipResp: true,
+		},
+		{
+			name: "literal path is anchored - does not match longer URL",
+			conf: SkipperConf{
+				DumpNoResponseBodyForPaths: []string{
+					"/users",
+				},
+			},
+			method:       http.MethodGet,
+			path:         "/users/123",
+			route:        "/users/:id",
+			wantSkipReq:  false,
+			wantSkipResp: false,
+		},
+		{
+			name: "literal path matches exactly",
+			conf: SkipperConf{
+				DumpNoResponseBodyForPaths: []string{
+					"/users",
+				},
+			},
+			method:       http.MethodGet,
+			path:         "/users",
+			route:        "/users",
+			wantSkipReq:  false,
+			wantSkipResp: true,
+		},
+		{
+			name: "route template is not treated as regex against URL path",
+			conf: SkipperConf{
+				DumpNoRequestBodyForPaths: []string{
+					"/ping/:id",
+				},
+			},
+			method:       http.MethodGet,
+			path:         "/ping/:id-debug",
+			route:        "/other/:id",
+			wantSkipReq:  false,
+			wantSkipResp: false,
+		},
+		{
+			name: "wildcard route template matched via endpoint",
+			conf: SkipperConf{
+				DumpNoRequestBodyForPaths: []string{
+					"/files/*",
+				},
+			},
+			method:       http.MethodGet,
+			path:         "/files/a/b",
+			route:        "/files/*",
+			body:         strings.NewReader("test"),
+			wantSkipReq:  true,
+			wantSkipResp: false,
 		},
 		{
 			name: "regex non-match does not skip",
@@ -114,12 +154,31 @@ func TestSkipper(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			skipper := NewEchoDumpBodySkipper(tt.conf)
+			skipper, err := New(tt.conf)
+			require.NoError(t, err)
 
 			ctx := newContext(tt.method, tt.path, tt.route, tt.body)
-			skipReqBody, skipRespBody := skipper.Skip(ctx)
+			skipReqBody, skipRespBody := skipper(ctx)
 			require.Equal(t, tt.wantSkipReq, skipReqBody)
 			require.Equal(t, tt.wantSkipResp, skipRespBody)
 		})
 	}
+}
+
+func TestNew_InvalidRegexReturnsError(t *testing.T) {
+	t.Run("invalid request pattern", func(t *testing.T) {
+		_, err := New(SkipperConf{
+			DumpNoRequestBodyForPaths: []string{"["},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "DumpNoRequestBodyForPaths")
+	})
+
+	t.Run("invalid response pattern", func(t *testing.T) {
+		_, err := New(SkipperConf{
+			DumpNoResponseBodyForPaths: []string{"("},
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "DumpNoResponseBodyForPaths")
+	})
 }

--- a/skipper_test.go
+++ b/skipper_test.go
@@ -166,19 +166,28 @@ func TestSkipper(t *testing.T) {
 }
 
 func TestNew_InvalidRegexReturnsError(t *testing.T) {
-	t.Run("invalid request pattern", func(t *testing.T) {
-		_, err := New(SkipperConf{
-			DumpNoRequestBodyForPaths: []string{"["},
-		})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "DumpNoRequestBodyForPaths")
-	})
+	tests := []struct {
+		name     string
+		conf     SkipperConf
+		wantField string
+	}{
+		{
+			name:      "invalid request pattern",
+			conf:      SkipperConf{DumpNoRequestBodyForPaths: []string{"["}},
+			wantField: "DumpNoRequestBodyForPaths",
+		},
+		{
+			name:      "invalid response pattern",
+			conf:      SkipperConf{DumpNoResponseBodyForPaths: []string{"("}},
+			wantField: "DumpNoResponseBodyForPaths",
+		},
+	}
 
-	t.Run("invalid response pattern", func(t *testing.T) {
-		_, err := New(SkipperConf{
-			DumpNoResponseBodyForPaths: []string{"("},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.conf)
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.wantField)
 		})
-		require.Error(t, err)
-		require.Contains(t, err.Error(), "DumpNoResponseBodyForPaths")
-	})
+	}
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,11 @@
+sonar.projectKey=adlandh_echo-dump-body-skipper
+sonar.organization=adlandh
+
+sonar.sources=.
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.exclusions=**/*_test.go
+
+sonar.cpd.exclusions=**/*_test.go
+
+sonar.go.coverage.reportPaths=coverage.out

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,11 +1,4 @@
 sonar.projectKey=adlandh_echo-dump-body-skipper
 sonar.organization=adlandh
 
-sonar.sources=.
-sonar.tests=.
-sonar.test.inclusions=**/*_test.go
-sonar.exclusions=**/*_test.go
-
 sonar.cpd.exclusions=**/*_test.go
-
-sonar.go.coverage.reportPaths=coverage.out

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,4 +1,0 @@
-sonar.projectKey=adlandh_echo-dump-body-skipper
-sonar.organization=adlandh
-
-sonar.cpd.exclusions=**/*_test.go


### PR DESCRIPTION
## Summary

Three breaking changes bundled for a v3 release. Each is independently motivated; bundling them avoids cutting multiple major versions back-to-back.

### 1. Distinguish Echo route templates from regex patterns
Previously, every entry in `DumpNoRequestBodyForPaths` / `DumpNoResponseBodyForPaths` was both inserted into the exact-match map *and* compiled as an unanchored regex. Two real consequences:

- A literal entry like `/users` would match `/users/123` via the unanchored regex.
- A route template like `/ping/:id` was a valid Go regex and would match any URL containing that substring.

Now, entries containing `/:` or `/*` (or ending in `*`) are recognized as Echo route templates and matched only against `c.Path()`. Everything else is treated as a regex against `URL.Path` and auto-anchored with `^...$` if not already anchored.

### 2. Surface invalid regex patterns at construction time
Previously, an invalid regex (e.g. a typo'd `^/users(`) was silently dropped, producing a no-op middleware. For a library that decides whether to log request bodies, silent misconfiguration is the wrong failure mode.

`New` now returns `(Skipper, error)`, with a wrapped error naming the offending field and pattern.

### 3. Drop the `BodySkipper` struct
The struct existed only to hold state that a closure already captures. `New` now returns the `Skipper` function directly, which:

- Eliminates the nil-`Skip` footgun from zero-value construction.
- Removes the stuttering `NewEchoDumpBodySkipper` constructor name in favor of `New`.

## Caller migration

```go
// before
skipper := echodumpbodyskipper.NewEchoDumpBodySkipper(cfg)
e.Use(mw.WithConfig(mw.Config{BodySkipper: skipper.Skip}))

// after
skipper, err := echodumpbodyskipper.New(cfg)
if err != nil {
    log.Fatal(err)
}
e.Use(mw.WithConfig(mw.Config{BodySkipper: skipper}))
```

## Test plan
- [x] `go test ./...` — 13 tests pass, 100% coverage
- [x] `go vet ./...` clean
- [x] `golangci-lint run` clean (enforced via pre-push hook)
- [x] New test coverage: anchored-literal non-match against longer URL, anchored-literal exact match, route template not treated as URL regex, wildcard route template, invalid-regex error path on both fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)